### PR TITLE
notebook 11: statistical hypothesis testing

### DIFF
--- a/e2ml/e2ml/evaluation/__init__.py
+++ b/e2ml/e2ml/evaluation/__init__.py
@@ -3,3 +3,4 @@ from ._visualization import *
 from ._performance_measures import *
 from ._performance_measures_II import *
 from ._error_estimation import *
+from ._one_sample_tests import *

--- a/e2ml/e2ml/evaluation/_one_sample_tests.py
+++ b/e2ml/e2ml/evaluation/_one_sample_tests.py
@@ -1,0 +1,117 @@
+import numpy as np
+
+from sklearn.utils.validation import check_array, check_scalar
+from scipy import stats
+
+
+def z_test_one_sample(sample_data, mu_0, sigma, test_type="two-sided"):
+    """Perform a one-sample z-test.
+
+    Parameters
+    ----------
+    sample_data : array-like of shape (n_samples,)
+        Sample data drawn from a population.
+    mu_0 : float or int
+        Population mean assumed by the null hypothesis.
+    sigma: float
+        True population standard deviation.
+    test_type : {'right-tail', 'left-tail', 'two-sided'}
+        Specifies the type of test for computing the p-value.
+        left-tail: Intergral links bis pvalue
+        right-tail: 1 - Integral links bis pvalue
+        two-sided: min etc.
+
+    Returns
+    -------
+    z_statistic : float
+        Observed z-transformed test statistic.
+    p : float
+        p-value for the observed sample data.
+    """
+    # Check parameters.
+    sample_data = check_array(sample_data, ensure_2d=False)
+    mu_0 = check_scalar(mu_0, name="mu_0", target_type=(int, float))
+    sigma = check_scalar(sigma, name="sigma", target_type=(int, float), min_val=0, include_boundaries="neither")
+    if test_type not in ["two-sided", "left-tail", "right-tail"]:
+        raise ValueError("`test_type` must be in `['two-sided', 'left-tail', 'right-tail']`")
+
+    # empirical mean
+    empirical_mean = np.mean(sample_data)
+
+    # sample size
+    sample_size = len(sample_data)
+
+    # z_statistic
+    # kommen empirical means aus gleichen Distributions?
+    z_statistic = (empirical_mean - mu_0) / (sigma / np.sqrt(sample_size))
+
+    # p-value
+    # depends on test_type
+    p_left = stats.norm.cdf(z_statistic)
+    p_right = 1 - p_left
+    if test_type == "left-tail":
+        p = p_left
+    elif test_type == "right-tail":
+        p = p_right
+    else:
+        p = 2 * min(p_left, p_right)
+
+    return z_statistic, p
+
+
+def t_test_one_sample(sample_data, mu_0, test_type="two-sided"):
+    """Perform a one-sample t-test.
+
+    Parameters
+    ----------
+    sample_data : array-like of shape (n_samples,)
+        Sample data drawn from a population.
+    mu_0 : float or int
+        Population mean assumed by the null hypothesis.
+    test_type : {'right-tail', 'left-tail', 'two-sided'}
+        Specifies the type of test for computing the p-value.
+
+    Returns
+    -------
+    t_statistic : float
+        Observed t-transformed test statistic.
+    p : float
+        p-value for the observed sample data.
+
+    Variance is estimated from the sample data (not given like in z-test).
+    """
+    # Check parameters.
+    sample_data = check_array(sample_data, ensure_2d=False)
+    mu_0 = check_scalar(mu_0, name="mu_0", target_type=(int, float))
+    if test_type not in ["two-sided", "left-tail", "right-tail"]:
+        raise ValueError("`test_type` must be in `['two-sided', 'left-tail', 'right-tail']`")
+
+    # empirical mean is test statistic
+    empirical_mean = np.mean(sample_data)
+
+    # empirical standard deviation
+    # ddof=1: Delta degrees of freedom. The divisor used in calculations is N - ddof, where N represents the number of elements.-> N-1 = ddf
+    empirical_sigma = np.std(sample_data, ddof=1)
+
+    # sample size
+    sample_size = len(sample_data)
+
+    # t_statistic
+    # kommen empirical means aus gleichen Distributions?
+    # sigma is not given, has to be estimated from sample data
+    # degrees of freedom = sample_size - 1; Letzter Datenpunkt ist aus N-1 anderen und mean berechenbar
+    t_statistic = (empirical_mean - mu_0) / (empirical_sigma / np.sqrt(sample_size))
+
+    # p-value
+    # depends on test_type
+    p_left = stats.t.cdf(t_statistic, df=sample_size - 1)    # df = degrees of freedom
+    p_right = 1 - p_left
+    if test_type == "left-tail":
+        p = p_left
+    elif test_type == "right-tail":
+        p = p_right
+    else:
+        p = 2 * min(p_left, p_right)
+
+    return t_statistic, p
+

--- a/e2ml/notebooks/11_statistical_hypothesis_testing_I.ipynb
+++ b/e2ml/notebooks/11_statistical_hypothesis_testing_I.ipynb
@@ -1,0 +1,277 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# Statistical Hypothesis Testing I\n",
+    "\n",
+    "In this notebook, we will implement and apply **statistical hypothesis tests** to make inferences about populations based on sample data.\n",
+    "\n",
+    "At the start, we clarify common misconceptions in statistical hypothesis testing.\n",
+    "\n",
+    "Subsequently, we will implement the one-sample $z$-test and the one-sample $t$-test.\n",
+    "\n",
+    "Finally, we will apply one of the tests to a concrete example.\n",
+    "\n",
+    "### **Table of Contents**\n",
+    "1. [Clarification of Misconceptions](#misconceptions)\n",
+    "2. [One-samples Tests](#one-sample-tests)\n",
+    "3. [Example](#example)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-06-30T11:50:26.551696900Z",
+     "start_time": "2023-06-30T11:50:25.396610300Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\klara\\anaconda3\\envs\\e2ml-env\\lib\\site-packages\\numpy\\_distributor_init.py:30: UserWarning: loaded more than 1 DLL from .libs:\n",
+      "C:\\Users\\klara\\anaconda3\\envs\\e2ml-env\\lib\\site-packages\\numpy\\.libs\\libopenblas.EL2C6PLE4ZYW3ECEVIV3OXXGRN2NRFM2.gfortran-win_amd64.dll\n",
+      "C:\\Users\\klara\\anaconda3\\envs\\e2ml-env\\lib\\site-packages\\numpy\\.libs\\libopenblas.GK7GX5KEQ4F6UYO3P26ULGBQYHGQO7J4.gfortran-win_amd64.dll\n",
+      "  warnings.warn(\"loaded more than 1 DLL from .libs:\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "from scipy import stats"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **1. Clarification of Misconceptions** <a class=\"anchor\" id=\"misconeptions\"></a>\n",
+    "Statistical hypothesis testing can often cause confusion and thus misconceptions, which we would like to clarify below.\n",
+    "\n",
+    "#### **Questions:**\n",
+    "1. (a) Is the $p$-value the probability that the null hypothesis $H_0$ is true given the data?\n",
+    "   \n",
+    "   Wahrscheinlichkeit extremere Werte (von H_0 distribution abweichende Werte) zu bekommen unter der Voraussetzung, dass H_0 war ist.\n",
+    "   \n",
+    "   (b) Are hypothesis tests carried out to decide if the H_0 is true or false?\n",
+    "\n",
+    "   Es gibt keine Sicherheit, es sind immer nur Indizien.\n",
+    "   Wenn das Siginificance level klein ist, kann man H_0 verwerfen.\n",
+    "   H_0 zu verwerfen kann sicherer gemacht werden, als zu sagen, dass sie wahr kist.\n",
+    "   Gegeben \\alpha: Sprechen Indizien gegen oder für H_0.\n",
+    "   Vermutung ist H_1, also das was man überprüfen will.\n",
+    "   \n",
+    "   (c) Are hypothesis tests carried out to establish the test statistic?\n",
+    "   \n",
+    "   Test Statistik beschreibt wie gut die Observations die distributions abbilden, die in der H_0 angenommen wurden.\n",
+    "   Hypothesis tests haben nicht (nur) die Aufgabe test statistics zu etablieren.\n",
+    "   Sie sollen Inferenzen möglich machen.\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **2. One-sample Tests** <a class=\"anchor\" id=\"one-sample-tests\"></a>\n",
+    "\n",
+    "We implement the function [`z_test_one_sample`](../e2ml/evaluation/_one_sample_tests.py) in the [`e2ml.evaluation`](../e2ml/evaluation) subpackage. Once, the implementation has been completed, we check it for varying types of tests."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-06-30T11:50:26.811502300Z",
+     "start_time": "2023-06-30T11:50:26.551696900Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from e2ml.evaluation import z_test_one_sample\n",
+    "sigma = 0.5\n",
+    "mu_0 = 2\n",
+    "sample_data = np.round(stats.norm.rvs(loc=2, scale=sigma, size=10, random_state=50), 1)\n",
+    "z_statistic, p = z_test_one_sample(sample_data=sample_data, mu_0=mu_0, sigma=sigma, test_type=\"right-tail\")\n",
+    "assert np.round(z_statistic, 4) == -1.5811 , 'The z-test statistic must be ca. 4.590.' \n",
+    "assert np.round(p, 4) == 0.9431, 'The p-value must be ca. 0.0007 for the one-sided right-tail test.' \n",
+    "z_statistic, p = z_test_one_sample(sample_data=sample_data, mu_0=mu_0, sigma=sigma, test_type=\"left-tail\")\n",
+    "assert np.round(z_statistic, 4) == -1.5811 , 'The z-test statistic must be ca. 4.590.' \n",
+    "assert np.round(p, 4) == 0.0569, 'The p-value must be ca. 0.9993 for the one-sided left-tail test.' \n",
+    "z_statistic, p = z_test_one_sample(sample_data=sample_data, mu_0=mu_0, sigma=sigma, test_type=\"two-sided\")\n",
+    "assert np.round(z_statistic, 4) == -1.5811 , 'The z-test statistic must be ca. 4.590.' \n",
+    "assert np.round(p, 4) == 0.1138, 'The p-value must be ca. 0.0014 for the two-sided test.' "
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We implement the function [`t_test_one_sample`](../e2ml/evaluation/_one_sample_tests.py) in the [`e2ml.evaluation`](../e2ml/evaluation) subpackage. Once, the implementation has been completed, we check it for varying types of tests."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-06-30T11:50:26.890473600Z",
+     "start_time": "2023-06-30T11:50:26.816103100Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from e2ml.evaluation import t_test_one_sample\n",
+    "sample_data = np.round(stats.norm.rvs(loc=13.5, scale=0.25, size=10, random_state=1), 1)\n",
+    "t_statistic, p = t_test_one_sample(sample_data=sample_data, mu_0=13, test_type=\"right-tail\")\n",
+    "assert np.round(t_statistic, 4) == 4.5898 , 'The t-test statistic must be ca. 4.590.' \n",
+    "assert np.round(p, 4) == 0.0007, 'The p-value must be ca. 0.0007 for the one-sided right-tail test.' \n",
+    "t_statistic, p = t_test_one_sample(sample_data=sample_data, mu_0=13, test_type=\"left-tail\")\n",
+    "assert np.round(t_statistic, 4) == 4.5898 , 'The t-test statistic must be ca. 4.590.' \n",
+    "assert np.round(p, 4) == 0.9993, 'The p-value must be ca. 0.9993 for the one-sided left-tail test.' \n",
+    "t_statistic, p = t_test_one_sample(sample_data=sample_data, mu_0=13, test_type=\"two-sided\")\n",
+    "assert np.round(t_statistic, 4) == 4.5898 , 'The t-test statistic must be ca. 4.590.' \n",
+    "assert np.round(p, 4) == 0.0013, 'The p-value must be ca. 0.0014 for the two-sided test.' "
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **3. Example** <a class=\"anchor\" id=\"example\"></a>"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let us assume we have access to the follwing *identically and independently distributed* (i.i.d.) heart rate measurements $[\\mathrm{beats/min}]$ of 40 patients in an *intensive care unit* (ICU):\n",
+    "\n",
+    "$124, 111,  96, 104,  89, 106,  94,  48, 117,  61, 117, 104,  72,\n",
+    "86, 126, 103,  97,  49,  78,  52, 119, 107, 131, 112,  78, 132,\n",
+    "80, 139,  87,  44,  40,  60,  40,  80,  41, 103, 102,  44, 115,\n",
+    "103.$\n",
+    "\n",
+    "#### **Questions:**\n",
+    "3. (a) Are heart rates from ICU patients unusual given normal heart rate has mean of 72 beats/min with a significance of .01? Perform a statistical hypothesis test by following the steps presented in the lecture and by using Python.\n",
+    "\n",
+    "   cf. below\n",
+    "\n",
+    "   p-hacking: \n",
+    "      - define alpha after p value is computed. \n",
+    "      - ziehe Subset of observed samples auf denen getestet: Obwohl Daten eigentlich von dist generiert wurden, sieht das bei gewissen Subsets nicht so aus. -> By chance effect der Hypothese zu schreiben.-> Wiederhole subsets ziehen\n",
+    "      -> Klausurrelevant. Youtube\n",
+    "\n",
+    "   Man kann nicht grundsätzlich sagen, ob es besser ist auf einen gesamten oder wiederholt auf subsamples zu testen.\n",
+    "   (Möglicherweise ab großen Datensätzen könnte wiederholtes subsamplen aussagekräftiger zu sein.)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-06-30T11:50:26.966661500Z",
+     "start_time": "2023-06-30T11:50:26.894621500Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reject H_0 with significance level alpha=0.01, and pvalue=0.0004\n"
+     ]
+    }
+   ],
+   "source": [
+    "data = [124, 111,  96, 104,  89, 106,  94,  48, 117,  61, 117, 104,  72,\n",
+    "86, 126, 103,  97,  49,  78,  52, 119, 107, 131, 112,  78, 132,\n",
+    "80, 139,  87,  44,  40,  60,  40,  80,  41, 103, 102,  44, 115,\n",
+    "103]\n",
+    "\n",
+    "# (1) define hypotheses\n",
+    "# H_0: mu = 72\n",
+    "# H_1: mu != 72\n",
+    "mu_0 = 72   # population mean\n",
+    "\n",
+    "# (2) select test statistic: Mittelwert\n",
+    "s_n = (1/len(data))*sum(data)\n",
+    "\n",
+    "# (3) find sampling distribution of test statistic under H_0\n",
+    "# z statistic: std is knownc & independent & normally distributed & enough (>30) samples -> NOT usable\n",
+    "# t statistic: std is unknown & independent & normally distributed & enough (>30) samples -> usable\n",
+    "# t transformation anwenden ==  treffen die Annahmen student t Verteilung ist zugrundeliegende Verteilung (aufgrund der erfüllten Voraussetzungen)\n",
+    "\n",
+    "# (4) define significance level: always define alpha before computing p-value\n",
+    "alpha = 0.01\n",
+    "\n",
+    "# (5) evaluate test statistic for observed data & (6) compute p-value\n",
+    "t_statistic, p = t_test_one_sample(sample_data=data, mu_0=mu_0, test_type=\"two-sided\")\n",
+    "\n",
+    "# (7) make decision\n",
+    "if p < alpha:\n",
+    "    print(\"Reject H_0 with significance level alpha={}, and pvalue={}\".format(np.round(alpha,4),np.round(p,4)))\n",
+    "else:\n",
+    "    print(\"Do not reject H_0\")\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-06-30T11:50:26.974033300Z",
+     "start_time": "2023-06-30T11:50:26.960099800Z"
+    }
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
In this notebook, statistical hypothesis tests are implemented and applied to make inferences about populations based on sample data.
At the start, common misconceptions in statistical hypothesis testing are clarified.
Subsequently, the one-sample  -test and the one-sample  -test are implemented.
Finally, one of the tests is applied to a concrete example.